### PR TITLE
feat: Modal de venda de números reservados

### DIFF
--- a/src/__tests__/components/RaffleNumberLegend.test.tsx
+++ b/src/__tests__/components/RaffleNumberLegend.test.tsx
@@ -26,3 +26,4 @@ describe('RaffleNumberLegend', () => {
 
 
 
+

--- a/src/__tests__/components/RaffleNumberListContainer-sale.test.tsx
+++ b/src/__tests__/components/RaffleNumberListContainer-sale.test.tsx
@@ -1,0 +1,241 @@
+import React from 'react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { RaffleNumberListContainer } from '@/components/RaffleNumberListContainer'
+import { raffleService } from '@/services/raffleService'
+
+// Mock do raffleService
+jest.mock('@/services/raffleService', () => ({
+  raffleService: {
+    getRaffleById: jest.fn(),
+    getRaffleNumbers: jest.fn(),
+    sellRaffleNumber: jest.fn()
+  }
+}))
+
+// Mock do componente RaffleSaleModal
+jest.mock('@/components/RaffleSaleModal', () => ({
+  RaffleSaleModal: ({ isOpen, onClose, raffle, onSaleSuccess }: any) => (
+    isOpen ? (
+      <div data-testid="sale-modal">
+        <div>Modal de Venda - {raffle.title}</div>
+        <button onClick={onClose}>Fechar Modal</button>
+        <button onClick={onSaleSuccess}>Simular Venda</button>
+      </div>
+    ) : null
+  )
+}))
+
+// Mock do componente RaffleNumberList
+jest.mock('@/components/RaffleNumberList', () => ({
+  RaffleNumberList: ({ numbers, raffleId, raffleInfo }: any) => (
+    <div data-testid="raffle-number-list">
+      <div>Números: {numbers.length}</div>
+      <div>Rifa ID: {raffleId}</div>
+      <div>Rifa Info: {raffleInfo?.title}</div>
+    </div>
+  )
+}))
+
+// Mock do componente RaffleNumberListPagination
+jest.mock('@/components/RaffleNumberListPagination', () => ({
+  RaffleNumberListPagination: () => <div data-testid="pagination">Pagination</div>
+}))
+
+// Mock do componente RaffleNumberLegend
+jest.mock('@/components/RaffleNumberLegend', () => ({
+  RaffleNumberLegend: () => <div data-testid="legend">Legend</div>
+}))
+
+const mockRaffleInfo = {
+  id: 'test-raffle-id',
+  title: 'Rifa de Teste',
+  description: 'Descrição da rifa',
+  prize: 'Prêmio',
+  maxNumbers: 100,
+  startAt: '2024-01-01T00:00:00Z',
+  endAt: '2024-12-31T23:59:59Z',
+  active: true,
+  createdAt: '2024-01-01T00:00:00Z',
+  updatedAt: '2024-01-01T00:00:00Z'
+}
+
+const mockNumbers = [
+  {
+    raffleId: 'test-raffle-id',
+    number: '1',
+    status: 'ACTIVE' as const,
+    winner: false,
+    reservedAt: null,
+    reservedBy: null,
+    soldAt: null,
+    soldBy: null,
+    owner: null
+  },
+  {
+    raffleId: 'test-raffle-id',
+    number: '2',
+    status: 'RESERVED' as const,
+    winner: false,
+    reservedAt: '2024-01-01T00:00:00Z',
+    reservedBy: 'user1',
+    soldAt: null,
+    soldBy: null,
+    owner: null
+  }
+]
+
+describe('RaffleNumberListContainer - Sale Functionality', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(raffleService.getRaffleById as jest.Mock).mockResolvedValue({
+      success: true,
+      data: mockRaffleInfo
+    })
+    ;(raffleService.getRaffleNumbers as jest.Mock).mockResolvedValue({
+      success: true,
+      data: {
+        rafflesNumbers: mockNumbers,
+        totalElements: 2,
+        pageNumber: 0,
+        pageSize: 20,
+        totalPages: 1,
+        hasNext: false,
+        hasPrevious: false,
+        first: true,
+        last: true
+      }
+    })
+  })
+
+  it('should render sale button', async () => {
+    render(<RaffleNumberListContainer raffleId="test-raffle-id" />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Vender')).toBeInTheDocument()
+    })
+  })
+
+  it('should open sale modal when clicking sell button', async () => {
+    render(<RaffleNumberListContainer raffleId="test-raffle-id" />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Vender')).toBeInTheDocument()
+    })
+
+    // Clicar no botão de venda
+    fireEvent.click(screen.getByText('Vender'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('sale-modal')).toBeInTheDocument()
+      expect(screen.getByText('Modal de Venda - Rifa de Teste')).toBeInTheDocument()
+    })
+  })
+
+  it('should close sale modal when clicking close button', async () => {
+    render(<RaffleNumberListContainer raffleId="test-raffle-id" />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Vender')).toBeInTheDocument()
+    })
+
+    // Abrir modal
+    fireEvent.click(screen.getByText('Vender'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('sale-modal')).toBeInTheDocument()
+    })
+
+    // Fechar modal
+    fireEvent.click(screen.getByText('Fechar Modal'))
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('sale-modal')).not.toBeInTheDocument()
+    })
+  })
+
+  it('should refresh numbers after successful sale', async () => {
+    render(<RaffleNumberListContainer raffleId="test-raffle-id" />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Vender')).toBeInTheDocument()
+    })
+
+    // Abrir modal
+    fireEvent.click(screen.getByText('Vender'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('sale-modal')).toBeInTheDocument()
+    })
+
+    // Simular venda bem-sucedida
+    fireEvent.click(screen.getByText('Simular Venda'))
+
+    // Verificar se os números foram recarregados
+    await waitFor(() => {
+      expect(raffleService.getRaffleNumbers).toHaveBeenCalledTimes(2)
+    })
+  })
+
+
+  it('should show sale button with correct styling', async () => {
+    render(<RaffleNumberListContainer raffleId="test-raffle-id" />)
+
+    await waitFor(() => {
+      const sellButton = screen.getByText('Vender')
+      expect(sellButton).toBeInTheDocument()
+      expect(sellButton).toHaveClass('text-green-700', 'bg-green-50', 'hover:bg-green-100')
+    })
+  })
+
+  it('should maintain other functionality while sale modal is open', async () => {
+    render(<RaffleNumberListContainer raffleId="test-raffle-id" />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Vender')).toBeInTheDocument()
+    })
+
+    // Abrir modal
+    fireEvent.click(screen.getByText('Vender'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('sale-modal')).toBeInTheDocument()
+    })
+
+    // Verificar se outros elementos ainda estão presentes
+    expect(screen.getByTestId('raffle-number-list')).toBeInTheDocument()
+    expect(screen.getByTestId('legend')).toBeInTheDocument()
+    expect(screen.getByTestId('pagination')).toBeInTheDocument()
+  })
+
+  it('should handle sale modal state correctly', async () => {
+    render(<RaffleNumberListContainer raffleId="test-raffle-id" />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Vender')).toBeInTheDocument()
+    })
+
+    // Modal não deve estar aberto inicialmente
+    expect(screen.queryByTestId('sale-modal')).not.toBeInTheDocument()
+
+    // Abrir modal
+    fireEvent.click(screen.getByText('Vender'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('sale-modal')).toBeInTheDocument()
+    })
+
+    // Fechar modal
+    fireEvent.click(screen.getByText('Fechar Modal'))
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('sale-modal')).not.toBeInTheDocument()
+    })
+
+    // Abrir novamente
+    fireEvent.click(screen.getByText('Vender'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('sale-modal')).toBeInTheDocument()
+    })
+  })
+})

--- a/src/__tests__/components/RaffleSaleModal.test.tsx
+++ b/src/__tests__/components/RaffleSaleModal.test.tsx
@@ -1,0 +1,481 @@
+import React from 'react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { RaffleSaleModal } from '@/components/RaffleSaleModal'
+import { RaffleResponse } from '@/types/raffle'
+import { raffleService } from '@/services/raffleService'
+
+// Mock do raffleService
+jest.mock('@/services/raffleService', () => ({
+  raffleService: {
+    getRaffleNumbers: jest.fn(),
+    sellRaffleNumber: jest.fn()
+  }
+}))
+
+// Mock do componente Toast
+jest.mock('@/components/Toast', () => ({
+  Toast: ({ message, onClose }: { message: string; onClose: () => void }) => (
+    <div data-testid="toast" onClick={onClose}>
+      {message}
+    </div>
+  )
+}))
+
+const mockRaffle: RaffleResponse = {
+  id: 'test-raffle-id',
+  title: 'Rifa de Teste',
+  description: 'Descrição da rifa de teste',
+  prize: 'Prêmio de teste',
+  maxNumbers: 100,
+  startAt: '2024-01-01T00:00:00Z',
+  endAt: '2024-12-31T23:59:59Z',
+  active: true,
+  createdAt: '2024-01-01T00:00:00Z',
+  updatedAt: '2024-01-01T00:00:00Z'
+}
+
+const mockReservedNumbers = [
+  {
+    raffleId: 'test-raffle-id',
+    number: '1',
+    status: 'RESERVED' as const,
+    winner: false,
+    reservedAt: '2024-01-01T00:00:00Z',
+    reservedBy: 'user1',
+    soldAt: null,
+    soldBy: null,
+    owner: null
+  },
+  {
+    raffleId: 'test-raffle-id',
+    number: '2',
+    status: 'RESERVED' as const,
+    winner: false,
+    reservedAt: '2024-01-01T00:00:00Z',
+    reservedBy: 'user2',
+    soldAt: null,
+    soldBy: null,
+    owner: null
+  },
+  {
+    raffleId: 'test-raffle-id',
+    number: '3',
+    status: 'RESERVED' as const,
+    winner: false,
+    reservedAt: '2024-01-01T00:00:00Z',
+    reservedBy: 'user3',
+    soldAt: null,
+    soldBy: null,
+    owner: null
+  }
+]
+
+describe('RaffleSaleModal', () => {
+  const mockOnClose = jest.fn()
+  const mockOnSaleSuccess = jest.fn()
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(raffleService.getRaffleNumbers as jest.Mock).mockResolvedValue({
+      success: true,
+      data: {
+        rafflesNumbers: mockReservedNumbers,
+        totalElements: 3,
+        pageNumber: 0,
+        pageSize: 20,
+        totalPages: 1,
+        hasNext: false,
+        hasPrevious: false,
+        first: true,
+        last: true
+      }
+    })
+    ;(raffleService.sellRaffleNumber as jest.Mock).mockResolvedValue({
+      success: true
+    })
+  })
+
+  it('should not render when isOpen is false', () => {
+    render(
+      <RaffleSaleModal
+        isOpen={false}
+        onClose={mockOnClose}
+        raffle={mockRaffle}
+        onSaleSuccess={mockOnSaleSuccess}
+      />
+    )
+
+    expect(screen.queryByText('Vender Números Reservados')).not.toBeInTheDocument()
+  })
+
+  it('should render modal when isOpen is true', async () => {
+    render(
+      <RaffleSaleModal
+        isOpen={true}
+        onClose={mockOnClose}
+        raffle={mockRaffle}
+        onSaleSuccess={mockOnSaleSuccess}
+      />
+    )
+
+    expect(screen.getByText('Vender Números Reservados')).toBeInTheDocument()
+    expect(screen.getByText('Rifa de Teste')).toBeInTheDocument()
+    expect(screen.getByText('Descrição da rifa de teste')).toBeInTheDocument()
+    
+    // Aguardar carregamento dos números
+    await waitFor(() => {
+      expect(screen.getByText('1')).toBeInTheDocument()
+      expect(screen.getByText('2')).toBeInTheDocument()
+      expect(screen.getByText('3')).toBeInTheDocument()
+    })
+  })
+
+  it('should show loading state initially', () => {
+    render(
+      <RaffleSaleModal
+        isOpen={true}
+        onClose={mockOnClose}
+        raffle={mockRaffle}
+        onSaleSuccess={mockOnSaleSuccess}
+      />
+    )
+
+    expect(screen.getByText('Carregando números reservados...')).toBeInTheDocument()
+  })
+
+  it('should show error state when loading fails', async () => {
+    ;(raffleService.getRaffleNumbers as jest.Mock).mockResolvedValue({
+      success: false,
+      message: 'Erro ao carregar números'
+    })
+
+    render(
+      <RaffleSaleModal
+        isOpen={true}
+        onClose={mockOnClose}
+        raffle={mockRaffle}
+        onSaleSuccess={mockOnSaleSuccess}
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Erro ao carregar números reservados')).toBeInTheDocument()
+      expect(screen.getByText('Tentar novamente')).toBeInTheDocument()
+    })
+  })
+
+  it('should show empty state when no reserved numbers', async () => {
+    ;(raffleService.getRaffleNumbers as jest.Mock).mockResolvedValue({
+      success: true,
+      data: {
+        rafflesNumbers: [],
+        totalElements: 0
+      }
+    })
+
+    render(
+      <RaffleSaleModal
+        isOpen={true}
+        onClose={mockOnClose}
+        raffle={mockRaffle}
+        onSaleSuccess={mockOnSaleSuccess}
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Nenhum número reservado encontrado')).toBeInTheDocument()
+    })
+  })
+
+  it('should allow selecting and deselecting numbers', async () => {
+    render(
+      <RaffleSaleModal
+        isOpen={true}
+        onClose={mockOnClose}
+        raffle={mockRaffle}
+        onSaleSuccess={mockOnSaleSuccess}
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('1')).toBeInTheDocument()
+    })
+
+    // Selecionar número 1
+    fireEvent.click(screen.getByText('1'))
+    expect(screen.getByText('1 de 3 selecionados')).toBeInTheDocument()
+
+    // Selecionar número 2
+    fireEvent.click(screen.getByText('2'))
+    expect(screen.getByText('2 de 3 selecionados')).toBeInTheDocument()
+
+    // Deselecionar número 1
+    fireEvent.click(screen.getByText('1'))
+    expect(screen.getByText('1 de 3 selecionados')).toBeInTheDocument()
+  })
+
+  it('should allow selecting all numbers', async () => {
+    render(
+      <RaffleSaleModal
+        isOpen={true}
+        onClose={mockOnClose}
+        raffle={mockRaffle}
+        onSaleSuccess={mockOnSaleSuccess}
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Selecionar todos')).toBeInTheDocument()
+    })
+
+    // Selecionar todos
+    fireEvent.click(screen.getByText('Selecionar todos'))
+    expect(screen.getByText('3 de 3 selecionados')).toBeInTheDocument()
+    expect(screen.getByText('Desmarcar todos')).toBeInTheDocument()
+
+    // Desmarcar todos
+    fireEvent.click(screen.getByText('Desmarcar todos'))
+    expect(screen.getByText('0 de 3 selecionados')).toBeInTheDocument()
+    expect(screen.getByText('Selecionar todos')).toBeInTheDocument()
+  })
+
+  it('should enable confirm button when numbers are selected', async () => {
+    render(
+      <RaffleSaleModal
+        isOpen={true}
+        onClose={mockOnClose}
+        raffle={mockRaffle}
+        onSaleSuccess={mockOnSaleSuccess}
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('1')).toBeInTheDocument()
+    })
+
+    // Selecionar um número
+    fireEvent.click(screen.getByText('1'))
+
+    const confirmButton = screen.getByText('Confirmar Venda (1)')
+    expect(confirmButton).not.toBeDisabled()
+  })
+
+
+  it('should successfully sell selected numbers', async () => {
+    render(
+      <RaffleSaleModal
+        isOpen={true}
+        onClose={mockOnClose}
+        raffle={mockRaffle}
+        onSaleSuccess={mockOnSaleSuccess}
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('1')).toBeInTheDocument()
+    })
+
+    // Selecionar números
+    fireEvent.click(screen.getByText('1'))
+    fireEvent.click(screen.getByText('2'))
+
+    // Confirmar venda
+    fireEvent.click(screen.getByText('Confirmar Venda (2)'))
+
+    await waitFor(() => {
+      expect(raffleService.sellRaffleNumber).toHaveBeenCalledTimes(2)
+      expect(raffleService.sellRaffleNumber).toHaveBeenCalledWith('test-raffle-id', 1)
+      expect(raffleService.sellRaffleNumber).toHaveBeenCalledWith('test-raffle-id', 2)
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('2 número(s) vendido(s) com sucesso!')).toBeInTheDocument()
+    })
+  })
+
+  it('should handle partial sale success', async () => {
+    ;(raffleService.sellRaffleNumber as jest.Mock)
+      .mockResolvedValueOnce({ success: true })
+      .mockRejectedValueOnce(new Error('Erro na venda'))
+
+    render(
+      <RaffleSaleModal
+        isOpen={true}
+        onClose={mockOnClose}
+        raffle={mockRaffle}
+        onSaleSuccess={mockOnSaleSuccess}
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('1')).toBeInTheDocument()
+    })
+
+    // Selecionar números
+    fireEvent.click(screen.getByText('1'))
+    fireEvent.click(screen.getByText('2'))
+
+    // Confirmar venda
+    fireEvent.click(screen.getByText('Confirmar Venda (2)'))
+
+    await waitFor(() => {
+      expect(screen.getByText('1 número(s) vendido(s) com sucesso. 1 falharam.')).toBeInTheDocument()
+    })
+  })
+
+  it('should handle complete sale failure', async () => {
+    ;(raffleService.sellRaffleNumber as jest.Mock).mockRejectedValue(new Error('Erro na venda'))
+
+    render(
+      <RaffleSaleModal
+        isOpen={true}
+        onClose={mockOnClose}
+        raffle={mockRaffle}
+        onSaleSuccess={mockOnSaleSuccess}
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('1')).toBeInTheDocument()
+    })
+
+    // Selecionar número
+    fireEvent.click(screen.getByText('1'))
+
+    // Confirmar venda
+    fireEvent.click(screen.getByText('Confirmar Venda (1)'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Erro ao vender os números selecionados')).toBeInTheDocument()
+    })
+  })
+
+  it('should close modal when clicking overlay', async () => {
+    render(
+      <RaffleSaleModal
+        isOpen={true}
+        onClose={mockOnClose}
+        raffle={mockRaffle}
+        onSaleSuccess={mockOnSaleSuccess}
+      />
+    )
+
+    const overlay = screen.getByTestId('overlay')
+    fireEvent.click(overlay)
+
+    expect(mockOnClose).toHaveBeenCalled()
+  })
+
+  it('should close modal when clicking close button', async () => {
+    render(
+      <RaffleSaleModal
+        isOpen={true}
+        onClose={mockOnClose}
+        raffle={mockRaffle}
+        onSaleSuccess={mockOnSaleSuccess}
+      />
+    )
+
+    // O botão de fechar é o primeiro botão (ícone X)
+    const closeButton = screen.getAllByRole('button')[0]
+    fireEvent.click(closeButton)
+
+    expect(mockOnClose).toHaveBeenCalled()
+  })
+
+  it('should close modal when clicking cancel button', async () => {
+    render(
+      <RaffleSaleModal
+        isOpen={true}
+        onClose={mockOnClose}
+        raffle={mockRaffle}
+        onSaleSuccess={mockOnSaleSuccess}
+      />
+    )
+
+    const cancelButton = screen.getByText('Cancelar')
+    fireEvent.click(cancelButton)
+
+    expect(mockOnClose).toHaveBeenCalled()
+  })
+
+  it('should call onSaleSuccess after successful sale', async () => {
+    render(
+      <RaffleSaleModal
+        isOpen={true}
+        onClose={mockOnClose}
+        raffle={mockRaffle}
+        onSaleSuccess={mockOnSaleSuccess}
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('1')).toBeInTheDocument()
+    })
+
+    // Selecionar número
+    fireEvent.click(screen.getByText('1'))
+
+    // Confirmar venda
+    fireEvent.click(screen.getByText('Confirmar Venda (1)'))
+
+    await waitFor(() => {
+      expect(screen.getByText('1 número(s) vendido(s) com sucesso!')).toBeInTheDocument()
+    })
+
+    // Aguardar fechamento automático
+    await waitFor(() => {
+      expect(mockOnSaleSuccess).toHaveBeenCalled()
+      expect(mockOnClose).toHaveBeenCalled()
+    }, { timeout: 2000 })
+  })
+
+  it('should refresh numbers when clicking refresh button', async () => {
+    render(
+      <RaffleSaleModal
+        isOpen={true}
+        onClose={mockOnClose}
+        raffle={mockRaffle}
+        onSaleSuccess={mockOnSaleSuccess}
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Atualizar')).toBeInTheDocument()
+    })
+
+    const refreshButton = screen.getByText('Atualizar')
+    fireEvent.click(refreshButton)
+
+    expect(raffleService.getRaffleNumbers).toHaveBeenCalledTimes(2)
+  })
+
+  it('should show selling state during sale process', async () => {
+    ;(raffleService.sellRaffleNumber as jest.Mock).mockImplementation(
+      () => new Promise(resolve => setTimeout(() => resolve({ success: true }), 100))
+    )
+
+    render(
+      <RaffleSaleModal
+        isOpen={true}
+        onClose={mockOnClose}
+        raffle={mockRaffle}
+        onSaleSuccess={mockOnSaleSuccess}
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('1')).toBeInTheDocument()
+    })
+
+    // Selecionar número
+    fireEvent.click(screen.getByText('1'))
+
+    // Confirmar venda
+    fireEvent.click(screen.getByText('Confirmar Venda (1)'))
+
+    // Verificar estado de venda
+    expect(screen.getByText('Vendendo...')).toBeInTheDocument()
+    expect(screen.getByText('Vendendo...')).toBeDisabled()
+  })
+})

--- a/src/__tests__/errorMessages.test.ts
+++ b/src/__tests__/errorMessages.test.ts
@@ -47,3 +47,4 @@ describe('errorMessages', () => {
 
 
 
+

--- a/src/__tests__/integration/raffle-sale-integration.test.tsx
+++ b/src/__tests__/integration/raffle-sale-integration.test.tsx
@@ -1,0 +1,325 @@
+import React from 'react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { RaffleNumberListContainer } from '@/components/RaffleNumberListContainer'
+import { raffleService } from '@/services/raffleService'
+
+// Mock do raffleService
+jest.mock('@/services/raffleService', () => ({
+  raffleService: {
+    getRaffleById: jest.fn(),
+    getRaffleNumbers: jest.fn(),
+    sellRaffleNumber: jest.fn()
+  }
+}))
+
+// Mock do componente RaffleNumberList
+jest.mock('@/components/RaffleNumberList', () => ({
+  RaffleNumberList: ({ numbers, raffleId, raffleInfo, onReserveSuccess }: any) => (
+    <div data-testid="raffle-number-list">
+      <div>Números: {numbers.length}</div>
+      <div>Rifa ID: {raffleId}</div>
+      <div>Rifa Info: {raffleInfo?.title}</div>
+      <button onClick={() => onReserveSuccess?.(1)}>Simular Reserva</button>
+    </div>
+  )
+}))
+
+// Mock do componente RaffleNumberListPagination
+jest.mock('@/components/RaffleNumberListPagination', () => ({
+  RaffleNumberListPagination: () => <div data-testid="pagination">Pagination</div>
+}))
+
+// Mock do componente RaffleNumberLegend
+jest.mock('@/components/RaffleNumberLegend', () => ({
+  RaffleNumberLegend: () => <div data-testid="legend">Legend</div>
+}))
+
+const mockRaffleInfo = {
+  id: 'test-raffle-id',
+  title: 'Rifa de Teste',
+  description: 'Descrição da rifa',
+  prize: 'Prêmio',
+  maxNumbers: 100,
+  startAt: '2024-01-01T00:00:00Z',
+  endAt: '2024-12-31T23:59:59Z',
+  active: true,
+  createdAt: '2024-01-01T00:00:00Z',
+  updatedAt: '2024-01-01T00:00:00Z'
+}
+
+const mockNumbers = [
+  {
+    raffleId: 'test-raffle-id',
+    number: '1',
+    status: 'ACTIVE' as const,
+    winner: false,
+    reservedAt: null,
+    reservedBy: null,
+    soldAt: null,
+    soldBy: null,
+    owner: null
+  },
+  {
+    raffleId: 'test-raffle-id',
+    number: '2',
+    status: 'RESERVED' as const,
+    winner: false,
+    reservedAt: '2024-01-01T00:00:00Z',
+    reservedBy: 'user1',
+    soldAt: null,
+    soldBy: null,
+    owner: null
+  },
+  {
+    raffleId: 'test-raffle-id',
+    number: '3',
+    status: 'RESERVED' as const,
+    winner: false,
+    reservedAt: '2024-01-01T00:00:00Z',
+    reservedBy: 'user2',
+    soldAt: null,
+    soldBy: null,
+    owner: null
+  }
+]
+
+describe('Raffle Sale Integration', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(raffleService.getRaffleById as jest.Mock).mockResolvedValue({
+      success: true,
+      data: mockRaffleInfo
+    })
+    ;(raffleService.getRaffleNumbers as jest.Mock).mockResolvedValue({
+      success: true,
+      data: {
+        rafflesNumbers: mockNumbers,
+        totalElements: 3,
+        pageNumber: 0,
+        pageSize: 20,
+        totalPages: 1,
+        hasNext: false,
+        hasPrevious: false,
+        first: true,
+        last: true
+      }
+    })
+    ;(raffleService.sellRaffleNumber as jest.Mock).mockResolvedValue({
+      success: true
+    })
+  })
+
+  it('should complete full sale workflow', async () => {
+    render(<RaffleNumberListContainer raffleId="test-raffle-id" />)
+
+    // Aguardar carregamento inicial
+    await waitFor(() => {
+      expect(screen.getByText('Vender')).toBeInTheDocument()
+    })
+
+    // Abrir modal de venda
+    fireEvent.click(screen.getByText('Vender'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Vender Números Reservados')).toBeInTheDocument()
+    })
+
+    // Verificar se números reservados são exibidos
+    expect(screen.getByText('2')).toBeInTheDocument() // Número reservado
+    expect(screen.getByText('3')).toBeInTheDocument() // Número reservado
+    expect(screen.queryByText('1')).not.toBeInTheDocument() // Número ativo não deve aparecer
+
+    // Selecionar números para venda
+    fireEvent.click(screen.getByText('2'))
+    fireEvent.click(screen.getByText('3'))
+
+    // Verificar contador de seleção
+    expect(screen.getByText('2 de 2 selecionados')).toBeInTheDocument()
+
+    // Confirmar venda
+    fireEvent.click(screen.getByText('Confirmar Venda (2)'))
+
+    // Verificar chamadas para API
+    await waitFor(() => {
+      expect(raffleService.sellRaffleNumber).toHaveBeenCalledTimes(2)
+      expect(raffleService.sellRaffleNumber).toHaveBeenCalledWith('test-raffle-id', 2)
+      expect(raffleService.sellRaffleNumber).toHaveBeenCalledWith('test-raffle-id', 3)
+    })
+
+    // Verificar mensagem de sucesso
+    await waitFor(() => {
+      expect(screen.getByText('2 número(s) vendido(s) com sucesso!')).toBeInTheDocument()
+    })
+
+    // Verificar se modal fecha automaticamente
+    await waitFor(() => {
+      expect(screen.queryByText('Vender Números Reservados')).not.toBeInTheDocument()
+    }, { timeout: 2000 })
+
+    // Verificar se números foram recarregados
+    await waitFor(() => {
+      expect(raffleService.getRaffleNumbers).toHaveBeenCalledTimes(3)
+    })
+  })
+
+  it('should handle partial sale failure', async () => {
+    ;(raffleService.sellRaffleNumber as jest.Mock)
+      .mockResolvedValueOnce({ success: true })
+      .mockRejectedValueOnce(new Error('Erro na venda'))
+
+    render(<RaffleNumberListContainer raffleId="test-raffle-id" />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Vender')).toBeInTheDocument()
+    })
+
+    // Abrir modal de venda
+    fireEvent.click(screen.getByText('Vender'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Vender Números Reservados')).toBeInTheDocument()
+    })
+
+    // Selecionar números
+    fireEvent.click(screen.getByText('2'))
+    fireEvent.click(screen.getByText('3'))
+
+    // Confirmar venda
+    fireEvent.click(screen.getByText('Confirmar Venda (2)'))
+
+    // Verificar mensagem de venda parcial
+    await waitFor(() => {
+      expect(screen.getByText('1 número(s) vendido(s) com sucesso. 1 falharam.')).toBeInTheDocument()
+    })
+  })
+
+  it('should handle complete sale failure', async () => {
+    ;(raffleService.sellRaffleNumber as jest.Mock).mockRejectedValue(new Error('Erro na venda'))
+
+    render(<RaffleNumberListContainer raffleId="test-raffle-id" />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Vender')).toBeInTheDocument()
+    })
+
+    // Abrir modal de venda
+    fireEvent.click(screen.getByText('Vender'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Vender Números Reservados')).toBeInTheDocument()
+    })
+
+    // Selecionar número
+    fireEvent.click(screen.getByText('2'))
+
+    // Confirmar venda
+    fireEvent.click(screen.getByText('Confirmar Venda (1)'))
+
+    // Verificar mensagem de erro
+    await waitFor(() => {
+      expect(screen.getByText('Erro ao vender os números selecionados')).toBeInTheDocument()
+    })
+  })
+
+  it('should handle empty reserved numbers', async () => {
+    ;(raffleService.getRaffleNumbers as jest.Mock).mockResolvedValue({
+      success: true,
+      data: {
+        rafflesNumbers: [mockNumbers[0]], // Apenas número ativo
+        totalElements: 1
+      }
+    })
+
+    render(<RaffleNumberListContainer raffleId="test-raffle-id" />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Vender')).toBeInTheDocument()
+    })
+
+    // Abrir modal de venda
+    fireEvent.click(screen.getByText('Vender'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Nenhum número reservado encontrado')).toBeInTheDocument()
+    })
+  })
+
+  it('should handle loading error', async () => {
+    ;(raffleService.getRaffleNumbers as jest.Mock).mockResolvedValue({
+      success: false,
+      message: 'Erro ao carregar números'
+    })
+
+    render(<RaffleNumberListContainer raffleId="test-raffle-id" />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Vender')).toBeInTheDocument()
+    })
+
+    // Abrir modal de venda
+    fireEvent.click(screen.getByText('Vender'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Erro ao carregar números reservados')).toBeInTheDocument()
+      expect(screen.getByText('Tentar novamente')).toBeInTheDocument()
+    })
+  })
+
+  it('should refresh numbers after successful sale', async () => {
+    render(<RaffleNumberListContainer raffleId="test-raffle-id" />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Vender')).toBeInTheDocument()
+    })
+
+    // Abrir modal de venda
+    fireEvent.click(screen.getByText('Vender'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Vender Números Reservados')).toBeInTheDocument()
+    })
+
+    // Selecionar e vender número
+    fireEvent.click(screen.getByText('2'))
+    fireEvent.click(screen.getByText('Confirmar Venda (1)'))
+
+    // Verificar se números foram recarregados após venda
+    await waitFor(() => {
+      expect(raffleService.getRaffleNumbers).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  it('should maintain state correctly during sale process', async () => {
+    ;(raffleService.sellRaffleNumber as jest.Mock).mockImplementation(
+      () => new Promise(resolve => setTimeout(() => resolve({ success: true }), 100))
+    )
+
+    render(<RaffleNumberListContainer raffleId="test-raffle-id" />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Vender')).toBeInTheDocument()
+    })
+
+    // Abrir modal de venda
+    fireEvent.click(screen.getByText('Vender'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Vender Números Reservados')).toBeInTheDocument()
+    })
+
+    // Selecionar número
+    fireEvent.click(screen.getByText('2'))
+
+    // Confirmar venda (deve mostrar estado de loading)
+    fireEvent.click(screen.getByText('Confirmar Venda (1)'))
+
+    // Verificar estado de venda
+    expect(screen.getByText('Vendendo...')).toBeInTheDocument()
+    expect(screen.getByText('Vendendo...')).toBeDisabled()
+
+    // Aguardar conclusão
+    await waitFor(() => {
+      expect(screen.getByText('1 número(s) vendido(s) com sucesso!')).toBeInTheDocument()
+    })
+  })
+})

--- a/src/__tests__/welcome-page.test.tsx
+++ b/src/__tests__/welcome-page.test.tsx
@@ -24,3 +24,4 @@ describe('Welcome Page', () => {
 
 
 
+

--- a/src/components/RaffleNumberLegend.tsx
+++ b/src/components/RaffleNumberLegend.tsx
@@ -21,3 +21,4 @@ export function RaffleNumberLegend() {
 
 
 
+

--- a/src/components/RaffleNumberListContainer.tsx
+++ b/src/components/RaffleNumberListContainer.tsx
@@ -6,6 +6,7 @@ import { raffleService } from '@/services/raffleService'
 import { RaffleNumberList } from './RaffleNumberList'
 import { RaffleNumberListPagination } from './RaffleNumberListPagination'
 import { RaffleNumberLegend } from './RaffleNumberLegend'
+import { RaffleSaleModal } from './RaffleSaleModal'
 
 interface RaffleNumberListContainerProps {
   raffleId: string
@@ -28,6 +29,7 @@ export function RaffleNumberListContainer({
   const [totalPages, setTotalPages] = useState(0)
   const [currentPageSize, setCurrentPageSize] = useState(pageSize)
   const [raffleInfo, setRaffleInfo] = useState<RaffleResponse | null>(null)
+  const [isSaleModalOpen, setIsSaleModalOpen] = useState(false)
 
   const loadRaffleInfo = async () => {
     try {
@@ -96,6 +98,11 @@ export function RaffleNumberListContainer({
     // Não logar mensagens de usuário como erros
   }
 
+  const handleSaleSuccess = () => {
+    // Recarregar os dados após venda bem-sucedida
+    loadNumbers(currentPage, currentPageSize)
+  }
+
   // Carregar informações da rifa quando o componente monta ou raffleId muda
   useEffect(() => {
     if (raffleId) {
@@ -123,21 +130,32 @@ export function RaffleNumberListContainer({
           )}
         </div>
         
-        <button
-          onClick={handleRefresh}
-          disabled={isLoading}
-          className="inline-flex items-center px-2 py-1 border border-gray-300 shadow-sm text-xs font-medium rounded text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-1 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
-        >
-          <svg 
-            className={`w-3 h-3 mr-1 ${isLoading ? 'animate-spin' : ''}`} 
-            fill="none" 
-            stroke="currentColor" 
-            viewBox="0 0 24 24"
+        <div className="flex items-center space-x-2">
+          <button
+            onClick={() => setIsSaleModalOpen(true)}
+            className="inline-flex items-center px-3 py-1 border border-green-300 shadow-sm text-xs font-medium rounded text-green-700 bg-green-50 hover:bg-green-100 focus:outline-none focus:ring-1 focus:ring-green-500"
           >
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
-          </svg>
-          Atualizar
-        </button>
+            <svg className="w-3 h-3 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1" />
+            </svg>
+            Vender
+          </button>
+          <button
+            onClick={handleRefresh}
+            disabled={isLoading}
+            className="inline-flex items-center px-2 py-1 border border-gray-300 shadow-sm text-xs font-medium rounded text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-1 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            <svg 
+              className={`w-3 h-3 mr-1 ${isLoading ? 'animate-spin' : ''}`} 
+              fill="none" 
+              stroke="currentColor" 
+              viewBox="0 0 24 24"
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+            </svg>
+            Atualizar
+          </button>
+        </div>
       </div>
 
       {/* Legenda */}
@@ -165,6 +183,16 @@ export function RaffleNumberListContainer({
           onItemsPerPageChange={handleItemsPerPageChange}
           onPageChange={handlePageChange}
           isLoading={isLoading}
+        />
+      )}
+
+      {/* Modal de venda */}
+      {raffleInfo && (
+        <RaffleSaleModal
+          isOpen={isSaleModalOpen}
+          onClose={() => setIsSaleModalOpen(false)}
+          raffle={raffleInfo}
+          onSaleSuccess={handleSaleSuccess}
         />
       )}
     </div>

--- a/src/components/RaffleSaleModal.tsx
+++ b/src/components/RaffleSaleModal.tsx
@@ -261,8 +261,6 @@ export function RaffleSaleModal({
               </div>
             </div>
           )}
-        </div>
-
           </div>
 
           {/* Footer */}

--- a/src/components/RaffleSaleModal.tsx
+++ b/src/components/RaffleSaleModal.tsx
@@ -144,36 +144,47 @@ export function RaffleSaleModal({
   if (!isOpen) return null
 
   return (
-    <div className="fixed inset-0 bg-gray-600 bg-opacity-50 overflow-y-auto h-full w-full z-50">
-      <div className="relative top-20 mx-auto p-5 border w-11/12 md:w-3/4 lg:w-1/2 shadow-lg rounded-md bg-white">
-        {/* Header */}
-        <div className="flex items-center justify-between mb-4">
-          <h3 className="text-lg font-medium text-gray-900">
-            Vender Números Reservados
-          </h3>
-          <button
-            onClick={handleClose}
-            className="text-gray-400 hover:text-gray-600"
-          >
-            <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-            </svg>
-          </button>
-        </div>
+    <div className="fixed inset-0 z-50 overflow-y-auto">
+      {/* Overlay */}
+      <div 
+        className="fixed inset-0 bg-transparent backdrop-blur-sm transition-opacity"
+        onClick={handleClose}
+        data-testid="overlay"
+      />
+      
+      {/* Modal */}
+      <div className="flex min-h-full items-center justify-center p-4">
+        <div className="relative w-full max-w-4xl bg-white rounded-lg shadow-xl">
+          {/* Header */}
+          <div className="flex items-center justify-between p-6 border-b border-gray-200">
+            <h3 className="text-lg font-semibold text-gray-900">
+              Vender Números Reservados
+            </h3>
+            <button
+              onClick={handleClose}
+              className="text-gray-400 hover:text-gray-600 transition-colors"
+            >
+              <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
 
-        {/* Informações da rifa */}
-        <div className="mb-4 p-3 bg-gray-50 rounded-md">
-          <h4 className="font-medium text-gray-900">{raffle.title}</h4>
-          <p className="text-sm text-gray-600">
-            {raffle.description && raffle.description.length > 100 
-              ? `${raffle.description.substring(0, 100)}...` 
-              : raffle.description
-            }
-          </p>
-        </div>
+          {/* Informações da rifa */}
+          <div className="p-6 border-b border-gray-200">
+            <div className="p-4 bg-gray-50 rounded-md">
+              <h4 className="font-medium text-gray-900">{raffle.title}</h4>
+              <p className="text-sm text-gray-600 mt-1">
+                {raffle.description && raffle.description.length > 100 
+                  ? `${raffle.description.substring(0, 100)}...` 
+                  : raffle.description
+                }
+              </p>
+            </div>
+          </div>
 
-        {/* Conteúdo */}
-        <div className="mb-6">
+          {/* Conteúdo */}
+          <div className="p-6">
           {isLoading ? (
             <div className="flex items-center justify-center py-8">
               <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-blue-500"></div>
@@ -252,22 +263,24 @@ export function RaffleSaleModal({
           )}
         </div>
 
-        {/* Footer */}
-        <div className="flex items-center justify-end space-x-3">
-          <button
-            onClick={handleClose}
-            className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500"
-          >
-            Cancelar
-          </button>
-          <button
-            onClick={handleConfirmSale}
-            disabled={selectedNumbers.size === 0 || isSelling}
-            className="px-4 py-2 text-sm font-medium text-white bg-green-600 border border-transparent rounded-md hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            {isSelling ? 'Vendendo...' : `Confirmar Venda (${selectedNumbers.size})`}
-          </button>
-        </div>
+          </div>
+
+          {/* Footer */}
+          <div className="flex items-center justify-end space-x-3 p-6 border-t border-gray-200 bg-gray-50 rounded-b-lg">
+            <button
+              onClick={handleClose}
+              className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 transition-colors"
+            >
+              Cancelar
+            </button>
+            <button
+              onClick={handleConfirmSale}
+              disabled={selectedNumbers.size === 0 || isSelling}
+              className="px-4 py-2 text-sm font-medium text-white bg-green-600 border border-transparent rounded-md hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            >
+              {isSelling ? 'Vendendo...' : `Confirmar Venda (${selectedNumbers.size})`}
+            </button>
+          </div>
 
         {/* Toast */}
         {toast && (
@@ -277,7 +290,9 @@ export function RaffleSaleModal({
             onClose={() => setToast(null)}
           />
         )}
+        </div>
       </div>
     </div>
   )
 }
+

--- a/src/components/RaffleSaleModal.tsx
+++ b/src/components/RaffleSaleModal.tsx
@@ -282,14 +282,14 @@ export function RaffleSaleModal({
             </button>
           </div>
 
-        {/* Toast */}
-        {toast && (
-          <Toast
-            message={toast.message}
-            type={toast.type}
-            onClose={() => setToast(null)}
-          />
-        )}
+          {/* Toast */}
+          {toast && (
+            <Toast
+              message={toast.message}
+              type={toast.type}
+              onClose={() => setToast(null)}
+            />
+          )}
         </div>
       </div>
     </div>

--- a/src/components/RaffleSaleModal.tsx
+++ b/src/components/RaffleSaleModal.tsx
@@ -1,0 +1,283 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { RaffleNumberItemResponse, RaffleResponse } from '@/types/raffle'
+import { raffleService } from '@/services/raffleService'
+import { Toast } from './Toast'
+
+interface RaffleSaleModalProps {
+  isOpen: boolean
+  onClose: () => void
+  raffle: RaffleResponse
+  onSaleSuccess?: () => void
+}
+
+export function RaffleSaleModal({ 
+  isOpen, 
+  onClose, 
+  raffle, 
+  onSaleSuccess 
+}: RaffleSaleModalProps) {
+  const [reservedNumbers, setReservedNumbers] = useState<RaffleNumberItemResponse[]>([])
+  const [isLoading, setIsLoading] = useState(false)
+  const [isSelling, setIsSelling] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [toast, setToast] = useState<{ message: string; type: 'success' | 'error' | 'warning' | 'info' } | null>(null)
+  const [selectedNumbers, setSelectedNumbers] = useState<Set<number>>(new Set())
+
+  // Carregar números reservados quando o modal abre
+  useEffect(() => {
+    if (isOpen && raffle.id) {
+      loadReservedNumbers()
+    }
+  }, [isOpen, raffle.id])
+
+  const loadReservedNumbers = async () => {
+    try {
+      setIsLoading(true)
+      setError(null)
+      
+      // Buscar todos os números da rifa (pode precisar de paginação para rifas grandes)
+      const response = await raffleService.getRaffleNumbers(raffle.id, 0, 1000)
+      
+      if (response.success && response.data) {
+        // Filtrar apenas os números reservados
+        const reserved = response.data.rafflesNumbers.filter(
+          (number: RaffleNumberItemResponse) => number.status === 'RESERVED'
+        )
+        setReservedNumbers(reserved)
+      } else {
+        setError('Erro ao carregar números reservados')
+      }
+    } catch (error) {
+      console.error('Erro ao carregar números reservados:', error)
+      setError('Erro ao carregar números reservados')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  const handleNumberToggle = (number: number) => {
+    const newSelected = new Set(selectedNumbers)
+    if (newSelected.has(number)) {
+      newSelected.delete(number)
+    } else {
+      newSelected.add(number)
+    }
+    setSelectedNumbers(newSelected)
+  }
+
+  const handleSelectAll = () => {
+    if (selectedNumbers.size === reservedNumbers.length) {
+      setSelectedNumbers(new Set())
+    } else {
+      setSelectedNumbers(new Set(reservedNumbers.map(n => parseInt(n.number))))
+    }
+  }
+
+  const handleConfirmSale = async () => {
+    if (selectedNumbers.size === 0) {
+      setToast({
+        message: 'Selecione pelo menos um número para vender',
+        type: 'warning'
+      })
+      return
+    }
+
+    try {
+      setIsSelling(true)
+      setError(null)
+
+      // Vender cada número selecionado
+      const salePromises = Array.from(selectedNumbers).map(number => 
+        raffleService.sellRaffleNumber(raffle.id, number)
+      )
+
+      const results = await Promise.allSettled(salePromises)
+      
+      // Verificar se todas as vendas foram bem-sucedidas
+      const failedSales = results.filter(result => result.status === 'rejected')
+      
+      if (failedSales.length === 0) {
+        setToast({
+          message: `${selectedNumbers.size} número(s) vendido(s) com sucesso!`,
+          type: 'success'
+        })
+        
+        // Fechar modal após sucesso
+        setTimeout(() => {
+          onSaleSuccess?.()
+          onClose()
+        }, 1500)
+      } else {
+        const successCount = results.length - failedSales.length
+        if (successCount > 0) {
+          setToast({
+            message: `${successCount} número(s) vendido(s) com sucesso. ${failedSales.length} falharam.`,
+            type: 'warning'
+          })
+        } else {
+          setToast({
+            message: 'Erro ao vender os números selecionados',
+            type: 'error'
+          })
+        }
+      }
+    } catch (error) {
+      console.error('Erro ao vender números:', error)
+      setToast({
+        message: 'Erro ao vender os números selecionados',
+        type: 'error'
+      })
+    } finally {
+      setIsSelling(false)
+    }
+  }
+
+  const handleClose = () => {
+    setSelectedNumbers(new Set())
+    setError(null)
+    setToast(null)
+    onClose()
+  }
+
+  if (!isOpen) return null
+
+  return (
+    <div className="fixed inset-0 bg-gray-600 bg-opacity-50 overflow-y-auto h-full w-full z-50">
+      <div className="relative top-20 mx-auto p-5 border w-11/12 md:w-3/4 lg:w-1/2 shadow-lg rounded-md bg-white">
+        {/* Header */}
+        <div className="flex items-center justify-between mb-4">
+          <h3 className="text-lg font-medium text-gray-900">
+            Vender Números Reservados
+          </h3>
+          <button
+            onClick={handleClose}
+            className="text-gray-400 hover:text-gray-600"
+          >
+            <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Informações da rifa */}
+        <div className="mb-4 p-3 bg-gray-50 rounded-md">
+          <h4 className="font-medium text-gray-900">{raffle.title}</h4>
+          <p className="text-sm text-gray-600">
+            {raffle.description && raffle.description.length > 100 
+              ? `${raffle.description.substring(0, 100)}...` 
+              : raffle.description
+            }
+          </p>
+        </div>
+
+        {/* Conteúdo */}
+        <div className="mb-6">
+          {isLoading ? (
+            <div className="flex items-center justify-center py-8">
+              <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-blue-500"></div>
+              <span className="ml-2 text-sm text-gray-600">Carregando números reservados...</span>
+            </div>
+          ) : error ? (
+            <div className="text-center py-8">
+              <div className="text-red-600 mb-2">
+                <svg className="mx-auto h-8 w-8 text-red-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L3.732 16.5c-.77.833.192 2.5 1.732 2.5z" />
+                </svg>
+              </div>
+              <p className="text-sm text-red-600">{error}</p>
+              <button
+                onClick={loadReservedNumbers}
+                className="mt-2 px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600"
+              >
+                Tentar novamente
+              </button>
+            </div>
+          ) : reservedNumbers.length === 0 ? (
+            <div className="text-center py-8">
+              <div className="text-gray-400 mb-2">
+                <svg className="mx-auto h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                </svg>
+              </div>
+              <p className="text-sm text-gray-500">Nenhum número reservado encontrado</p>
+            </div>
+          ) : (
+            <div>
+              {/* Controles */}
+              <div className="flex items-center justify-between mb-4">
+                <div className="flex items-center space-x-2">
+                  <button
+                    onClick={handleSelectAll}
+                    className="text-sm text-blue-600 hover:text-blue-800"
+                  >
+                    {selectedNumbers.size === reservedNumbers.length ? 'Desmarcar todos' : 'Selecionar todos'}
+                  </button>
+                  <span className="text-sm text-gray-500">
+                    {selectedNumbers.size} de {reservedNumbers.length} selecionados
+                  </span>
+                </div>
+                <button
+                  onClick={loadReservedNumbers}
+                  disabled={isLoading}
+                  className="text-sm text-gray-600 hover:text-gray-800 disabled:opacity-50"
+                >
+                  Atualizar
+                </button>
+              </div>
+
+              {/* Grid de números */}
+              <div className="grid grid-cols-6 md:grid-cols-8 lg:grid-cols-10 gap-2 max-h-64 overflow-y-auto">
+                {reservedNumbers.map((number) => {
+                  const isSelected = selectedNumbers.has(parseInt(number.number))
+                  return (
+                    <button
+                      key={number.number}
+                      onClick={() => handleNumberToggle(parseInt(number.number))}
+                      className={`
+                        p-2 text-sm font-medium rounded border-2 transition-colors
+                        ${isSelected 
+                          ? 'bg-blue-500 text-white border-blue-500' 
+                          : 'bg-white text-gray-700 border-gray-300 hover:border-blue-300'
+                        }
+                      `}
+                    >
+                      {number.number}
+                    </button>
+                  )
+                })}
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-end space-x-3">
+          <button
+            onClick={handleClose}
+            className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500"
+          >
+            Cancelar
+          </button>
+          <button
+            onClick={handleConfirmSale}
+            disabled={selectedNumbers.size === 0 || isSelling}
+            className="px-4 py-2 text-sm font-medium text-white bg-green-600 border border-transparent rounded-md hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {isSelling ? 'Vendendo...' : `Confirmar Venda (${selectedNumbers.size})`}
+          </button>
+        </div>
+
+        {/* Toast */}
+        {toast && (
+          <Toast
+            message={toast.message}
+            type={toast.type}
+            onClose={() => setToast(null)}
+          />
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -92,3 +92,4 @@ export function Toast({ message, type, duration = 5000, onClose }: ToastProps) {
 
 
 
+

--- a/src/docs/error-handling.md
+++ b/src/docs/error-handling.md
@@ -207,3 +207,4 @@ export function ReserveNumberButton({ raffleId, number }) {
 
 
 
+

--- a/src/hooks/useErrorHandler.ts
+++ b/src/hooks/useErrorHandler.ts
@@ -65,3 +65,4 @@ export function useErrorHandler(options: UseErrorHandlerOptions = {}) {
 
 
 
+

--- a/src/utils/errorMessages.ts
+++ b/src/utils/errorMessages.ts
@@ -146,3 +146,4 @@ export function isConflictError(error: unknown): boolean {
 
 
 
+


### PR DESCRIPTION
## Descrição
Implementa funcionalidade para venda de números reservados de rifas através de um modal intuitivo.

## Funcionalidades
- ✅ Modal para exibir números reservados
- ✅ Seleção múltipla de números para venda
- ✅ Botão de venda no componente de números
- ✅ Integração com API de venda do backend
- ✅ Tratamento de sucesso e erro com feedback visual
- ✅ Funcionalidade de selecionar/deselecionar todos
- ✅ Design consistente com outros modais

## Como usar
1. Acesse uma rifa e vá para a aba de números
2. Clique no botão 'Vender' (verde) no cabeçalho
3. Selecione os números reservados que deseja vender
4. Clique em 'Confirmar Venda'
5. Receba feedback de sucesso ou erro

## API utilizada
- `POST /v1/raffles/{raffleId}/numbers/sold`
- `GET /v1/raffles/{raffleId}/numbers` (para buscar números reservados)

## Testes
- ✅ Todos os testes existentes passando
- ✅ Sem erros de linting
- ✅ Componente totalmente funcional