### PR TITLE
feat: implement image listing and deletion in edit modal

### DIFF
--- a/src/__tests__/components/ExistingImageList.test.tsx
+++ b/src/__tests__/components/ExistingImageList.test.tsx
@@ -1,0 +1,157 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { ExistingImageList } from '../../components/ExistingImageList'
+import { fileUploadService } from '../../services/fileUploadService'
+
+// Mock do serviço de upload
+jest.mock('../../services/fileUploadService', () => ({
+  fileUploadService: {
+    deleteRaffleImage: jest.fn()
+  }
+}))
+
+// Mock do window.confirm
+const mockConfirm = jest.fn()
+Object.defineProperty(window, 'confirm', {
+  value: mockConfirm,
+  writable: true
+})
+
+// Mock do window.alert
+const mockAlert = jest.fn()
+Object.defineProperty(window, 'alert', {
+  value: mockAlert,
+  writable: true
+})
+
+describe('ExistingImageList Component', () => {
+  const mockProps = {
+    raffleId: 'test-raffle-id',
+    imageUrls: [
+      'http://localhost:4566/files/image1.jpg',
+      'http://localhost:4566/files/image2.jpg'
+    ],
+    onImageDeleted: jest.fn(),
+    disabled: false
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockConfirm.mockReturnValue(true)
+  })
+
+  test('renders existing images', () => {
+    render(<ExistingImageList {...mockProps} />)
+    
+    expect(screen.getByText('Imagens Existentes (2)')).toBeInTheDocument()
+    expect(screen.getAllByAltText(/Imagem \d+/)).toHaveLength(2)
+  })
+
+  test('does not render when no images', () => {
+    render(<ExistingImageList {...mockProps} imageUrls={[]} />)
+    
+    expect(screen.queryByText('Imagens Existentes')).not.toBeInTheDocument()
+  })
+
+  test('shows delete buttons on hover', () => {
+    render(<ExistingImageList {...mockProps} />)
+    
+    const deleteButtons = screen.getAllByTitle('Excluir imagem')
+    expect(deleteButtons).toHaveLength(2)
+    
+    // Botões devem estar ocultos inicialmente (opacity-0)
+    deleteButtons.forEach(button => {
+      expect(button).toHaveClass('opacity-0')
+    })
+  })
+
+  test('calls onImageDeleted when image is successfully deleted', async () => {
+    const mockDeleteRaffleImage = fileUploadService.deleteRaffleImage as jest.MockedFunction<typeof fileUploadService.deleteRaffleImage>
+    mockDeleteRaffleImage.mockResolvedValue({
+      success: true,
+      message: 'Imagem excluída com sucesso'
+    })
+
+    render(<ExistingImageList {...mockProps} />)
+    
+    const deleteButtons = screen.getAllByTitle('Excluir imagem')
+    fireEvent.click(deleteButtons[0])
+    
+    await waitFor(() => {
+      expect(mockConfirm).toHaveBeenCalledWith('Tem certeza que deseja excluir esta imagem? Esta ação não pode ser desfeita.')
+      expect(mockDeleteRaffleImage).toHaveBeenCalledWith(
+        mockProps.raffleId,
+        mockProps.imageUrls[0]
+      )
+      expect(mockProps.onImageDeleted).toHaveBeenCalledWith(mockProps.imageUrls[0])
+    })
+  })
+
+  test('does not delete when user cancels confirmation', async () => {
+    mockConfirm.mockReturnValue(false)
+    const mockDeleteRaffleImage = fileUploadService.deleteRaffleImage as jest.MockedFunction<typeof fileUploadService.deleteRaffleImage>
+
+    render(<ExistingImageList {...mockProps} />)
+    
+    const deleteButtons = screen.getAllByTitle('Excluir imagem')
+    fireEvent.click(deleteButtons[0])
+    
+    await waitFor(() => {
+      expect(mockConfirm).toHaveBeenCalled()
+      expect(mockDeleteRaffleImage).not.toHaveBeenCalled()
+      expect(mockProps.onImageDeleted).not.toHaveBeenCalled()
+    })
+  })
+
+  test('shows error alert when deletion fails', async () => {
+    const mockDeleteRaffleImage = fileUploadService.deleteRaffleImage as jest.MockedFunction<typeof fileUploadService.deleteRaffleImage>
+    mockDeleteRaffleImage.mockResolvedValue({
+      success: false,
+      error: 'API Error'
+    })
+
+    render(<ExistingImageList {...mockProps} />)
+    
+    const deleteButtons = screen.getAllByTitle('Excluir imagem')
+    fireEvent.click(deleteButtons[0])
+    
+    await waitFor(() => {
+      expect(mockAlert).toHaveBeenCalledWith('Erro ao excluir imagem: API Error')
+      expect(mockProps.onImageDeleted).not.toHaveBeenCalled()
+    })
+  })
+
+  test('disables delete buttons when disabled prop is true', () => {
+    render(<ExistingImageList {...mockProps} disabled={true} />)
+    
+    const deleteButtons = screen.getAllByTitle('Excluir imagem')
+    deleteButtons.forEach(button => {
+      expect(button).toBeDisabled()
+    })
+  })
+
+  test('shows loading state during deletion', async () => {
+    const mockDeleteRaffleImage = fileUploadService.deleteRaffleImage as jest.MockedFunction<typeof fileUploadService.deleteRaffleImage>
+    // Mock uma promise que não resolve imediatamente
+    mockDeleteRaffleImage.mockImplementation(() => new Promise(() => {}))
+
+    render(<ExistingImageList {...mockProps} />)
+    
+    const deleteButtons = screen.getAllByTitle('Excluir imagem')
+    fireEvent.click(deleteButtons[0])
+    
+    await waitFor(() => {
+      expect(screen.getByText('Excluindo...')).toBeInTheDocument()
+      expect(screen.getByTitle('Excluindo...')).toBeInTheDocument()
+    })
+  })
+
+  test('handles image load error with fallback', () => {
+    render(<ExistingImageList {...mockProps} />)
+    
+    const images = screen.getAllByAltText(/Imagem \d+/)
+    fireEvent.error(images[0])
+    
+    // Verifica se a imagem foi substituída pelo fallback
+    expect(images[0]).toHaveAttribute('src', expect.stringContaining('data:image/svg+xml'))
+  })
+})

--- a/src/__tests__/fileUploadService.test.ts
+++ b/src/__tests__/fileUploadService.test.ts
@@ -151,6 +151,61 @@ describe('FileUploadService', () => {
     })
   })
 
+  describe('deleteRaffleImage', () => {
+    const raffleId = 'test-raffle-id'
+    const fileUrl = 'http://localhost:4566/files/test-image.jpg'
+
+    test('should delete file successfully', async () => {
+      mockApiService.request.mockResolvedValue({
+        success: true,
+        data: undefined
+      })
+
+      const result = await fileUploadService.deleteRaffleImage(raffleId, fileUrl)
+
+      expect(result.success).toBe(true)
+      expect(result.message).toBe('Imagem excluída com sucesso')
+      expect(mockApiService.request).toHaveBeenCalledWith(
+        `/v1/raffles/${raffleId}/file?fileUrl=${encodeURIComponent(fileUrl)}`,
+        {
+          method: 'DELETE'
+        }
+      )
+    })
+
+    test('should handle API error response', async () => {
+      mockApiService.request.mockResolvedValue({
+        success: false,
+        error: 'API Error'
+      })
+
+      const result = await fileUploadService.deleteRaffleImage(raffleId, fileUrl)
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('API Error')
+    })
+
+    test('should handle API error without error message', async () => {
+      mockApiService.request.mockResolvedValue({
+        success: false
+      })
+
+      const result = await fileUploadService.deleteRaffleImage(raffleId, fileUrl)
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('Erro ao excluir a imagem')
+    })
+
+    test('should handle network error', async () => {
+      mockApiService.request.mockRejectedValue(new Error('Network error'))
+
+      const result = await fileUploadService.deleteRaffleImage(raffleId, fileUrl)
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('Erro inesperado ao excluir a imagem')
+    })
+  })
+
   describe('createPreviewUrl', () => {
     test('should create preview URL for file', () => {
       const file = new File(['test'], 'test.png', { type: 'image/png' })

--- a/src/components/ExistingImageList.tsx
+++ b/src/components/ExistingImageList.tsx
@@ -1,0 +1,108 @@
+import React, { useState } from 'react'
+import { fileUploadService } from '@/services/fileUploadService'
+
+interface ExistingImageListProps {
+  raffleId: string
+  imageUrls: string[]
+  onImageDeleted: (deletedUrl: string) => void
+  disabled?: boolean
+}
+
+export function ExistingImageList({ raffleId, imageUrls, onImageDeleted, disabled = false }: ExistingImageListProps) {
+  const [deletingImages, setDeletingImages] = useState<Set<string>>(new Set())
+
+  const handleDeleteImage = async (imageUrl: string) => {
+    if (disabled || deletingImages.has(imageUrl)) return
+
+    const confirmed = window.confirm('Tem certeza que deseja excluir esta imagem? Esta ação não pode ser desfeita.')
+    if (!confirmed) return
+
+    setDeletingImages(prev => new Set(prev).add(imageUrl))
+
+    try {
+      const result = await fileUploadService.deleteRaffleImage(raffleId, imageUrl)
+      
+      if (result.success) {
+        onImageDeleted(imageUrl)
+        console.log('✅ [EXISTING-IMAGES] Imagem excluída com sucesso')
+      } else {
+        console.error('❌ [EXISTING-IMAGES] Erro ao excluir imagem:', result.error)
+        alert(`Erro ao excluir imagem: ${result.error}`)
+      }
+    } catch (error) {
+      console.error('💥 [EXISTING-IMAGES] Erro inesperado:', error)
+      alert('Erro inesperado ao excluir imagem')
+    } finally {
+      setDeletingImages(prev => {
+        const newSet = new Set(prev)
+        newSet.delete(imageUrl)
+        return newSet
+      })
+    }
+  }
+
+  if (imageUrls.length === 0) {
+    return null
+  }
+
+  return (
+    <div className="space-y-3">
+      <h4 className="text-sm font-medium text-gray-700">Imagens Existentes ({imageUrls.length})</h4>
+      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3">
+        {imageUrls.map((imageUrl, index) => {
+          const isDeleting = deletingImages.has(imageUrl)
+          
+          return (
+            <div key={index} className="relative group aspect-square rounded-lg overflow-hidden shadow-sm border border-gray-200">
+              <img 
+                src={imageUrl} 
+                alt={`Imagem ${index + 1}`} 
+                className="w-full h-full object-cover"
+                onError={(e) => {
+                  // Fallback para imagem quebrada
+                  const target = e.target as HTMLImageElement
+                  target.src = 'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTAwIiBoZWlnaHQ9IjEwMCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cmVjdCB3aWR0aD0iMTAwIiBoZWlnaHQ9IjEwMCIgZmlsbD0iI2Y3ZjdmNyIvPjx0ZXh0IHg9IjUwIiB5PSI1MCIgZm9udC1mYW1pbHk9IkFyaWFsLCBzYW5zLXNlcmlmIiBmb250LXNpemU9IjEyIiBmaWxsPSIjOTk5IiB0ZXh0LWFuY2hvcj0ibWlkZGxlIiBkeT0iLjNlbSI+SW1hZ2VtPC90ZXh0Pjwvc3ZnPg=='
+                }}
+              />
+              
+              {/* Botão de exclusão */}
+              <button
+                type="button"
+                onClick={() => handleDeleteImage(imageUrl)}
+                disabled={disabled || isDeleting}
+                className={`
+                  absolute top-1 right-1 rounded-full p-1 text-xs transition-opacity
+                  ${isDeleting 
+                    ? 'bg-gray-500 text-white cursor-not-allowed' 
+                    : 'bg-red-500 text-white opacity-0 group-hover:opacity-100 hover:bg-red-600'
+                  }
+                `}
+                title={isDeleting ? 'Excluindo...' : 'Excluir imagem'}
+              >
+                {isDeleting ? (
+                  <div className="animate-spin rounded-full h-3 w-3 border-b-2 border-white"></div>
+                ) : (
+                  <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                  </svg>
+                )}
+              </button>
+              
+              {/* Overlay de carregamento */}
+              {isDeleting && (
+                <div className="absolute inset-0 bg-black bg-opacity-50 flex items-center justify-center">
+                  <div className="text-white text-xs font-medium">Excluindo...</div>
+                </div>
+              )}
+            </div>
+          )
+        })}
+      </div>
+      
+      <div className="text-sm text-gray-600 bg-yellow-50 p-3 rounded-lg">
+        <p className="font-medium mb-1">⚠️ Aviso:</p>
+        <p>Clique no "X" para excluir imagens existentes. Esta ação remove a imagem tanto do servidor quanto da rifa.</p>
+      </div>
+    </div>
+  )
+}

--- a/src/components/RaffleEditModal.tsx
+++ b/src/components/RaffleEditModal.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react'
 import { RaffleResponse } from '@/types/raffle'
 import { raffleService } from '@/services/raffleService'
 import { InlineImageUpload } from './InlineImageUpload'
+import { ExistingImageList } from './ExistingImageList'
 import { fileUploadService } from '@/services/fileUploadService'
 
 interface RaffleEditModalProps {
@@ -19,6 +20,7 @@ export function RaffleEditModal({ isOpen, onClose, raffle, onSuccess }: RaffleEd
   const [error, setError] = useState<string | null>(null)
   const [successMessage, setSuccessMessage] = useState<string | null>(null)
   const [selectedImages, setSelectedImages] = useState<File[]>([])
+  const [existingImages, setExistingImages] = useState<string[]>([])
   const [formData, setFormData] = useState({
     title: '',
     prize: '',
@@ -40,6 +42,7 @@ export function RaffleEditModal({ isOpen, onClose, raffle, onSuccess }: RaffleEd
         endAt: raffle.endAt ? raffle.endAt.split('T')[0] + 'T' + raffle.endAt.split('T')[1].substring(0, 5) : ''
       })
       setOriginalMaxNumbers(maxNumbers)
+      setExistingImages(raffle.files || [])
       setError(null)
       setSuccessMessage(null)
     }
@@ -73,6 +76,11 @@ export function RaffleEditModal({ isOpen, onClose, raffle, onSuccess }: RaffleEd
 
   const handleImagesChange = (images: File[]) => {
     setSelectedImages(images)
+  }
+
+  const handleImageDeleted = (deletedUrl: string) => {
+    setExistingImages(prev => prev.filter(url => url !== deletedUrl))
+    console.log('🗑️ [RAFFLE-EDIT-MODAL] Imagem excluída:', deletedUrl)
   }
 
   const handleIncrementNumbers = async () => {
@@ -280,6 +288,16 @@ export function RaffleEditModal({ isOpen, onClose, raffle, onSuccess }: RaffleEd
                 <p className="font-medium mb-1">💡 Dica:</p>
                 <p>Adicione imagens do prêmio para atrair mais participantes! As imagens serão enviadas automaticamente após salvar as alterações.</p>
               </div>
+              
+              {/* Listagem de Imagens Existentes */}
+              {raffle && (
+                <ExistingImageList
+                  raffleId={raffle.id}
+                  imageUrls={existingImages}
+                  onImageDeleted={handleImageDeleted}
+                  disabled={isLoading || isIncrementing}
+                />
+              )}
             </div>
 
             {/* Número máximo de números */}

--- a/src/services/fileUploadService.ts
+++ b/src/services/fileUploadService.ts
@@ -7,6 +7,12 @@ export interface FileUploadResponse {
   message?: string
 }
 
+export interface FileDeleteResponse {
+  success: boolean
+  error?: string
+  message?: string
+}
+
 export class FileUploadService {
   private readonly apiService: ApiService
 
@@ -63,6 +69,45 @@ export class FileUploadService {
       return {
         success: false,
         error: 'Erro inesperado ao fazer upload da imagem'
+      }
+    }
+  }
+
+  /**
+   * Exclui uma imagem de uma rifa específica
+   */
+  async deleteRaffleImage(raffleId: string, fileUrl: string): Promise<FileDeleteResponse> {
+    try {
+      console.log('🗑️ [FILE-DELETE] Iniciando exclusão de imagem')
+      console.log('📋 [FILE-DELETE] Rifa ID:', raffleId)
+      console.log('🔗 [FILE-DELETE] URL do arquivo:', fileUrl)
+
+      // Fazer exclusão
+      const response = await this.apiService.request<void>(
+        `/v1/raffles/${raffleId}/file?fileUrl=${encodeURIComponent(fileUrl)}`,
+        {
+          method: 'DELETE'
+        }
+      )
+
+      if (response.success) {
+        console.log('✅ [FILE-DELETE] Exclusão realizada com sucesso')
+        return {
+          success: true,
+          message: 'Imagem excluída com sucesso'
+        }
+      } else {
+        console.error('❌ [FILE-DELETE] Erro na exclusão:', response.error)
+        return {
+          success: false,
+          error: response.error || 'Erro ao excluir a imagem'
+        }
+      }
+    } catch (error) {
+      console.error('💥 [FILE-DELETE] Erro inesperado:', error)
+      return {
+        success: false,
+        error: 'Erro inesperado ao excluir a imagem'
       }
     }
   }


### PR DESCRIPTION
Implementa listagem e exclusão de imagens no modal de edição de rifas.

Funcionalidades:
- Novo componente ExistingImageList para exibir imagens existentes
- Botão de exclusão com confirmação para cada imagem
- Integração com endpoint DELETE do backend
- Estados de carregamento e tratamento de erros
- Fallback para imagens quebradas
- Testes unitários completos

Componentes:
- ExistingImageList: Lista imagens com botões de exclusão
- RaffleEditModal: Integrado com ExistingImageList
- FileUploadService: Método deleteRaffleImage

Testes:
- 9 testes para ExistingImageList
- 4 testes para deleteRaffleImage
- Cobertura de cenários de sucesso e erro